### PR TITLE
Add devcontainer structure with devcontainer.json

### DIFF
--- a/devcontainer/devfile.yaml
+++ b/devcontainer/devfile.yaml
@@ -1,0 +1,15 @@
+schemaVersion: 2.2.2
+metadata:
+  name: tmpbichr46p.devfile-6e13a4ec
+components:
+  - name: tooling-container
+    container:
+      image: ghcr.io/ansible/ansible-workspace-env-reference:latest
+      memoryRequest: 256M
+      memoryLimit: 6Gi
+      cpuRequest: 250m
+      cpuLimit: 2000m
+      args: ["tail", "-f", "/dev/null"]
+      env:
+        - name: KUBEDOCK_ENABLED
+          value: "true"


### PR DESCRIPTION
This PR adds the devcontainer folder structure with devcontainer.json files for Docker and Podman.